### PR TITLE
Import AVSC files for Avro-serializable objects

### DIFF
--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmdetobs.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmdetobs.cs
@@ -4,6 +4,71 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
+
+    /*
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointIsmdetobs",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "NavigationSystem",
+     *       "type": {
+     * 	"name": "NovAtelLogReader.LogData.NavigationSystem",
+     * 	"type": "enum",
+     * 	"symbols": [
+     * 	  "GPS",
+     * 	  "GLONASS",
+     * 	  "SBAS",
+     * 	  "Galileo",
+     * 	  "BeiDou",
+     * 	  "QZSS",
+     * 	  "Reserved",
+     * 	  "Other"
+     * 	]
+     *       }
+     *     },
+     *     {
+     *       "name": "Power",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "SignalType",
+     *       "type": {
+     * 	"name": "NovAtelLogReader.LogData.SignalType",
+     * 	"type": "enum",
+     * 	"symbols": [
+     * 	  "Unknown",
+     * 	  "L1CA",
+     * 	  "L2C",
+     * 	  "L2CA",
+     * 	  "L2P",
+     * 	  "L2P_codeless",
+     * 	  "L2Y",
+     * 	  "L5Q"
+     * 	]
+     *       }
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     }
+     *   ]
+     * }
+     *
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "ISMDETOBS", Queue = "datapoint-raw-ismdetobs")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmrawtec.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmrawtec.cs
@@ -4,6 +4,74 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
+    /*
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointIsmrawtec",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "NavigationSystem",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.NavigationSystem",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "GPS",
+     *           "GLONASS",
+     *           "SBAS",
+     *           "Galileo",
+     *           "BeiDou",
+     *           "QZSS",
+     *           "Reserved",
+     *           "Other"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "PrimarySignal",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.SignalType",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "Unknown",
+     *           "L1CA",
+     *           "L2C",
+     *           "L2CA",
+     *           "L2P",
+     *           "L2P_codeless",
+     *           "L2Y",
+     *           "L5Q"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "SecondarySignal",
+     *       "type": "NovAtelLogReader.LogData.SignalType"
+     *     },
+     *     {
+     *       "name": "Tec",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     }
+     *   ]
+     * }
+     *
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "ISMRAWTEC", Queue = "datapoint-raw-ismrawtec")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmredobs.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmredobs.cs
@@ -4,6 +4,93 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
+    /*
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointIsmredobs",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "AverageCmc",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "CmcStdDev",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "CorrS4",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "NavigationSystem",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.NavigationSystem",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "GPS",
+     *           "GLONASS",
+     *           "SBAS",
+     *           "Galileo",
+     *           "BeiDou",
+     *           "QZSS",
+     *           "Reserved",
+     *           "Other"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "PhaseSigma1Second",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "PhaseSigma30Second",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "PhaseSigma60Second",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "SignalType",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.SignalType",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "Unknown",
+     *           "L1CA",
+     *           "L2C",
+     *           "L2CA",
+     *           "L2P",
+     *           "L2P_codeless",
+     *           "L2Y",
+     *           "L5Q"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     },
+     *     {
+     *       "name": "TotalS4",
+     *       "type": "double"
+     *     }
+     *   ]
+     * }
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "ISMREDOBS", Queue = "datapoint-raw-ismredobs")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointPsrpos.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointPsrpos.cs
@@ -3,6 +3,43 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
+    /*
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointPsrpos",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "Hgt",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "HgtStdDev",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Lat",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "LatStdDev",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Lon",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "LonStdDev",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     }
+     *   ]
+     * }
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "PSRPOS", Queue = "datapoint-raw-psrpos")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointRange.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointRange.cs
@@ -4,6 +4,87 @@ using NovAtelLogReader.LogData;
 
 namespace NovAtelLogReader.DataPoints
 {
+    /*
+     *
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointRange",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "Adr",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "CNo",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "LockTime",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "NavigationSystem",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.NavigationSystem",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "GPS",
+     *           "GLONASS",
+     *           "SBAS",
+     *           "Galileo",
+     *           "BeiDou",
+     *           "QZSS",
+     *           "Reserved",
+     *           "Other"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "Power",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Psr",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "SignalType",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.SignalType",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "Unknown",
+     *           "L1CA",
+     *           "L2C",
+     *           "L2CA",
+     *           "L2P",
+     *           "L2P_codeless",
+     *           "L2Y",
+     *           "L5Q"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     }
+     *   ]
+     * }
+     *
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "RANGE", Queue = "datapoint-raw-range")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatvis.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatvis.cs
@@ -4,6 +4,65 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
+    /*
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointSatvis",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "Az",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Elev",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Health",
+     *       "type": "long"
+     *     },
+     *     {
+     *       "name": "NavigationSystem",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.NavigationSystem",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "GPS",
+     *           "GLONASS",
+     *           "SBAS",
+     *           "Galileo",
+     *           "BeiDou",
+     *           "QZSS",
+     *           "Reserved",
+     *           "Other"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "SatVis",
+     *       "type": "boolean"
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     }
+     *   ]
+     * }
+     *
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "SATVIS", Queue = "datapoint-raw-satvis")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatxyz2.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatxyz2.cs
@@ -4,6 +4,57 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
+    /*
+     *
+     *
+     * {
+     *   "name": "NovAtelLogReader.DataPoints.DataPointSatxyz2",
+     *   "type": "record",
+     *   "fields": [
+     *     {
+     *       "name": "NavigationSystem",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.NavigationSystem",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "GPS",
+     *           "GLONASS",
+     *           "SBAS",
+     *           "Galileo",
+     *           "BeiDou",
+     *           "QZSS",
+     *           "Reserved",
+     *           "Other"
+     *         ]
+     *       }
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     },
+     *     {
+     *       "name": "X",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Y",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Z",
+     *       "type": "double"
+     *     }
+     *   ]
+     * }
+     * */
     [DataContract]
     [Serializable]
     [DataPoint(Name = "SATXYZ2", Queue = "datapoint-raw-satxyz2")]


### PR DESCRIPTION
Оказывается, можно сгенерировать их автоматических из объектов, при
помощи `dotnet avro create`. Подробности смотри в [1][1] и [2][2].
Для "автоматического" определения структуры объектов Kafka / Spark.

[1]: https://stackoverflow.com/questions/45338832/can-a-c-sharp-model-be-serialized-as-an-avro-json-schema
[2]: https://engineering.chrobinson.com/dotnet-avro/guides/cli-create/