### PR TITLE
Initial settings + cutoff

### DIFF
--- a/NovAtelLogReader/NovAtelLogReader/App.config
+++ b/NovAtelLogReader/NovAtelLogReader/App.config
@@ -47,9 +47,9 @@
                         <!-- <string>ISMSIGNALCONTROL GPSL2P ENABLE ENABLE</string> -->
                         <!-- <string>LOG PSRPOSB ONTIME 1</string> -->
                         <string>LOG RANGEB ONTIME 0.02</string>
-                        <!-- <string>LOG ISMRAWTECB ONNEW</string> -->
-                        <!-- <string>LOG ISMDETOBSB ONNEW</string> -->
-                        <!-- <string>LOG ISMREDOBSB ONNEW</string> -->
+                        <string>LOG ISMRAWTECB ONNEW</string>
+                        <string>LOG ISMDETOBSB ONNEW</string>
+                        <string>LOG ISMREDOBSB ONNEW</string>
                         <string>LOG SATXYZ2B ONTIME 10</string>
                     </ArrayOfString>
                 </value>

--- a/NovAtelLogReader/NovAtelLogReader/App.config
+++ b/NovAtelLogReader/NovAtelLogReader/App.config
@@ -66,6 +66,9 @@
                         <string>ISMSIGNALCONTROL QZSSL2C disable disable</string>
                         <string>ISMSIGNALCONTROL QZSSL5 disable disable</string>
 
+                        <!-- Enable SDCB & RDCB -->
+                        <string>DIFFCODEBIASCONTROLA ENABLE</string>
+
                         <!-- <string>CNOUPDATE 20HZ</string> -->
                         <!-- <string>DIFFCODEBIASCONTROL DISABLE</string> -->
                         <!-- <string>EXTERNALCLOCK DISABLE</string> -->

--- a/NovAtelLogReader/NovAtelLogReader/App.config
+++ b/NovAtelLogReader/NovAtelLogReader/App.config
@@ -46,6 +46,26 @@
                         <string>LOCKOUTSYSTEM SBAS</string>
                         <string>LOCKOUTSYSTEM GALILEO</string>
                         <string>LOCKOUTSYSTEM QZSS</string>
+
+                        <!-- Disable unsupported sygnals -->
+                        <string>ISMSIGNALCONTROL GPSL1CA enable enable</string>
+                        <string>ISMSIGNALCONTROL GPSL2Y disable disable</string>
+                        <string>ISMSIGNALCONTROL GPSL2C enable enable</string>
+                        <string>ISMSIGNALCONTROL GPSL2P enable enable</string>
+                        <string>ISMSIGNALCONTROL GPSL5 disable disable</string>
+                        <string>ISMSIGNALCONTROL GLOL1CA enable enable</string>
+                        <string>ISMSIGNALCONTROL GLOL2CA enable enable</string>
+                        <string>ISMSIGNALCONTROL GLOL2P enable enable</string>
+                        <string>ISMSIGNALCONTROL SBASL1 disable disable</string>
+                        <string>ISMSIGNALCONTROL SBASL5 disable disable</string>
+                        <string>ISMSIGNALCONTROL GALE1 disable disable</string>
+                        <string>ISMSIGNALCONTROL GALE5A disable disable</string>
+                        <string>ISMSIGNALCONTROL GALE5B disable disable</string>
+                        <string>ISMSIGNALCONTROL GALALTBOC disable disable</string>
+                        <string>ISMSIGNALCONTROL QZSSL1CA disable disable</string>
+                        <string>ISMSIGNALCONTROL QZSSL2C disable disable</string>
+                        <string>ISMSIGNALCONTROL QZSSL5 disable disable</string>
+
                         <!-- <string>CNOUPDATE 20HZ</string> -->
                         <!-- <string>DIFFCODEBIASCONTROL DISABLE</string> -->
                         <!-- <string>EXTERNALCLOCK DISABLE</string> -->

--- a/NovAtelLogReader/NovAtelLogReader/App.config
+++ b/NovAtelLogReader/NovAtelLogReader/App.config
@@ -38,6 +38,9 @@
                     <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>UNLOGALL TRUE</string>
+
+                        <!-- Cut-off less 30 degree values -->
+                        <string>ELEVATIONCUTOFF ALL 30.0</string>
                         <!-- <string>CNOUPDATE 20HZ</string> -->
                         <!-- <string>DIFFCODEBIASCONTROL DISABLE</string> -->
                         <!-- <string>EXTERNALCLOCK DISABLE</string> -->

--- a/NovAtelLogReader/NovAtelLogReader/App.config
+++ b/NovAtelLogReader/NovAtelLogReader/App.config
@@ -41,6 +41,11 @@
 
                         <!-- Cut-off less 30 degree values -->
                         <string>ELEVATIONCUTOFF ALL 30.0</string>
+
+                        <!-- Disable unsupported systems -->
+                        <string>LOCKOUTSYSTEM SBAS</string>
+                        <string>LOCKOUTSYSTEM GALILEO</string>
+                        <string>LOCKOUTSYSTEM QZSS</string>
                         <!-- <string>CNOUPDATE 20HZ</string> -->
                         <!-- <string>DIFFCODEBIASCONTROL DISABLE</string> -->
                         <!-- <string>EXTERNALCLOCK DISABLE</string> -->


### PR DESCRIPTION
Разумные настройки по-умолчанию:

- Включены старые логи, используются для отладки
- Включена отсечка спутников, если они находятся ниже 30 градусов от уровня горизонта.
  Позволяет избежать частых потерь сигнала на низких углах из-за переотражений
- Отключены нереализованные навигационные системы и сигналы. Они не несут (пока что)
  полезную информацию и только отвлекают внимание
- Включен учет поправок 