### PR TITLE
Don't store *.config inside container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# NET-core configs
+**/*.config

--- a/NovAtelLogReader/NovAtelLogReader/NovAtelLogReader.csproj
+++ b/NovAtelLogReader/NovAtelLogReader/NovAtelLogReader.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="NLog.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/README.md
+++ b/README.md
@@ -5,12 +5,16 @@ NovAtelLogReader
 
 1. Склонировать репозиторий
 
-2. Установить требуемые настройки
+2. Собрать контейнер
+
+   ```sh
+   docker build -t novatellogreader .
+   ```
+
+3. Установить требуемые настройки
 
    Изменить настройки в файле по-умолчанию
-   (`NovAtelLogReader/NovAtelLogReader/App.config`) либо примонтировать файл с
-   установленными настройками на место файла
-   `NovAtelLogReader/NovAtelLogReader/NovAtelLogReader.dll.conf`.
+   (`NovAtelLogReader/NovAtelLogReader/App.config`).
 
    Порт GPS-приёмника можно определить при помощи:
 
@@ -26,23 +30,27 @@ NovAtelLogReader
 
    Так же необходимо прописать в `/etc/hosts` адрес хоста `kafka`.
 
-3. Собрать контейнер
-
-   ```sh
-   docker build -t novatellogreader .
-   ```
-
 4. Запустить контейнер
 
    Для доступа к портам GPS-приёмника необходимо пробросить эти устройства
    внутрь контейнера, примонтировав всю файловую систему */dev*:
 
    ```sh
-   docker run --rm -v /dev/:/dev/ -v /etc/hosts:/etc/hosts -d novatellogreader:latest
+   docker run --rm -v /dev/:/dev/ \
+          -v /etc/hosts:/etc/hosts \
+          -v `realpath NovAtelLogReader/NovAtelRunner/App.config`:/app/NovAtelRunner.dll.config \
+          -v `realpath NovAtelLogReader/NovAtelLogReader/App.config`:/app/NovAtelLogReader.dll.config \
+          -v `realpath NovAtelLogReader/NovAtelLogReader/NLog.config`:/app/NLog.config \
+          -d novatellogreader:latest
    ```
 
    Либо пробросив соответвующее устройство при запуске контейнера:
 
    ```sh
-   docker run --rm --device '<полное_имя_устройства>' -v /etc/hosts:/etc/hosts -d novatellogreader:latest
+   docker run --rm --device '<полное_имя_устройства>' \
+          -v /etc/hosts:/etc/hosts \
+          -v `realpath NovAtelLogReader/NovAtelRunner/App.config`:/app/NovAtelRunner.dll.config \
+          -v `realpath NovAtelLogReader/NovAtelLogReader/App.config`:/app/NovAtelLogReader.dll.config \
+          -v `realpath NovAtelLogReader/NovAtelLogReader/NLog.config`:/app/NLog.config \
+          -d novatellogreader:latest
    ```


### PR DESCRIPTION
Сейчас контейнер необходимо пересобрать, чтобы применить любые изменения в
конфигах, **каждый раз**! Не очень удобно.

Этот PR вводит возможность сборки контейнера без учета конфигов. Docker не будет
считать необходимой пересборку. Так же контейнер теперь не имеет *разумных значений
по-умолчанию* внутри и не спобен запуститься без дополнительных параметров, но и
не будет пересобираться при изменении конфигов.