### PR TITLE
Fix: Avro schemes fields order

### DIFF
--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmdetobs.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmdetobs.cs
@@ -4,7 +4,6 @@ using System.Runtime.Serialization;
 
 namespace NovAtelLogReader.DataPoints
 {
-
     /*
      *
      * {
@@ -12,63 +11,64 @@ namespace NovAtelLogReader.DataPoints
      *   "type": "record",
      *   "fields": [
      *     {
-     *       "name": "GloFreq",
-     *       "type": "int"
+     *       "name": "Timestamp",
+     *       "type": "long"
      *     },
      *     {
      *       "name": "NavigationSystem",
      *       "type": {
-     * 	"name": "NovAtelLogReader.LogData.NavigationSystem",
-     * 	"type": "enum",
-     * 	"symbols": [
-     * 	  "GPS",
-     * 	  "GLONASS",
-     * 	  "SBAS",
-     * 	  "Galileo",
-     * 	  "BeiDou",
-     * 	  "QZSS",
-     * 	  "Reserved",
-     * 	  "Other"
-     * 	]
+     *         "name": "NovAtelLogReader.LogData.NavigationSystem",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "GPS",
+     *           "GLONASS",
+     *           "SBAS",
+     *           "Galileo",
+     *           "BeiDou",
+     *           "QZSS",
+     *           "Reserved",
+     *           "Other"
+     *         ]
      *       }
      *     },
      *     {
-     *       "name": "Power",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "Prn",
-     *       "type": "int"
+     *       "name": "SignalType",
+     *       "type": {
+     *         "name": "NovAtelLogReader.LogData.SignalType",
+     *         "type": "enum",
+     *         "symbols": [
+     *           "Unknown",
+     *           "L1CA",
+     *           "L2C",
+     *           "L2CA",
+     *           "L2P",
+     *           "L2P_codeless",
+     *           "L2Y",
+     *           "L5Q"
+     *         ]
+     *       }
      *     },
      *     {
      *       "name": "Satellite",
      *       "type": "string"
      *     },
      *     {
-     *       "name": "SignalType",
-     *       "type": {
-     * 	"name": "NovAtelLogReader.LogData.SignalType",
-     * 	"type": "enum",
-     * 	"symbols": [
-     * 	  "Unknown",
-     * 	  "L1CA",
-     * 	  "L2C",
-     * 	  "L2CA",
-     * 	  "L2P",
-     * 	  "L2P_codeless",
-     * 	  "L2Y",
-     * 	  "L5Q"
-     * 	]
-     *       }
+     *       "name": "Prn",
+     *       "type": "int"
      *     },
      *     {
-     *       "name": "Timestamp",
-     *       "type": "long"
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Power",
+     *       "type": "double"
      *     }
      *   ]
      * }
      *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "ISMDETOBS", Queue = "datapoint-raw-ismdetobs")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmrawtec.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmrawtec.cs
@@ -11,8 +11,8 @@ namespace NovAtelLogReader.DataPoints
      *   "type": "record",
      *   "fields": [
      *     {
-     *       "name": "GloFreq",
-     *       "type": "int"
+     *       "name": "Timestamp",
+     *       "type": "long"
      *     },
      *     {
      *       "name": "NavigationSystem",
@@ -32,6 +32,18 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
      *       "name": "PrimarySignal",
      *       "type": {
      *         "name": "NovAtelLogReader.LogData.SignalType",
@@ -49,29 +61,18 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
-     *       "name": "Prn",
-     *       "type": "int"
-     *     },
-     *     {
-     *       "name": "Satellite",
-     *       "type": "string"
-     *     },
-     *     {
      *       "name": "SecondarySignal",
      *       "type": "NovAtelLogReader.LogData.SignalType"
      *     },
      *     {
      *       "name": "Tec",
      *       "type": "double"
-     *     },
-     *     {
-     *       "name": "Timestamp",
-     *       "type": "long"
      *     }
      *   ]
      * }
      *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "ISMRAWTEC", Queue = "datapoint-raw-ismrawtec")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmredobs.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointIsmredobs.cs
@@ -11,20 +11,8 @@ namespace NovAtelLogReader.DataPoints
      *   "type": "record",
      *   "fields": [
      *     {
-     *       "name": "AverageCmc",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "CmcStdDev",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "CorrS4",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "GloFreq",
-     *       "type": "int"
+     *       "name": "Timestamp",
+     *       "type": "long"
      *     },
      *     {
      *       "name": "NavigationSystem",
@@ -44,26 +32,6 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
-     *       "name": "PhaseSigma1Second",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "PhaseSigma30Second",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "PhaseSigma60Second",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "Prn",
-     *       "type": "int"
-     *     },
-     *     {
-     *       "name": "Satellite",
-     *       "type": "string"
-     *     },
-     *     {
      *       "name": "SignalType",
      *       "type": {
      *         "name": "NovAtelLogReader.LogData.SignalType",
@@ -81,16 +49,50 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
-     *       "name": "Timestamp",
-     *       "type": "long"
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "AverageCmc",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "CmcStdDev",
+     *       "type": "double"
      *     },
      *     {
      *       "name": "TotalS4",
      *       "type": "double"
+     *     },
+     *     {
+     *       "name": "CorrS4",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "PhaseSigma1Second",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "PhaseSigma30Second",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "PhaseSigma60Second",
+     *       "type": "double"
      *     }
      *   ]
      * }
+     *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "ISMREDOBS", Queue = "datapoint-raw-ismredobs")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointPsrpos.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointPsrpos.cs
@@ -10,19 +10,11 @@ namespace NovAtelLogReader.DataPoints
      *   "type": "record",
      *   "fields": [
      *     {
-     *       "name": "Hgt",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "HgtStdDev",
-     *       "type": "double"
+     *       "name": "Timestamp",
+     *       "type": "long"
      *     },
      *     {
      *       "name": "Lat",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "LatStdDev",
      *       "type": "double"
      *     },
      *     {
@@ -30,16 +22,26 @@ namespace NovAtelLogReader.DataPoints
      *       "type": "double"
      *     },
      *     {
+     *       "name": "Hgt",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "LatStdDev",
+     *       "type": "double"
+     *     },
+     *     {
      *       "name": "LonStdDev",
      *       "type": "double"
      *     },
      *     {
-     *       "name": "Timestamp",
-     *       "type": "long"
+     *       "name": "HgtStdDev",
+     *       "type": "double"
      *     }
      *   ]
      * }
+     *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "PSRPOS", Queue = "datapoint-raw-psrpos")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointRange.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointRange.cs
@@ -6,26 +6,13 @@ namespace NovAtelLogReader.DataPoints
 {
     /*
      *
-     *
      * {
      *   "name": "NovAtelLogReader.DataPoints.DataPointRange",
      *   "type": "record",
      *   "fields": [
      *     {
-     *       "name": "Adr",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "CNo",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "GloFreq",
-     *       "type": "int"
-     *     },
-     *     {
-     *       "name": "LockTime",
-     *       "type": "double"
+     *       "name": "Timestamp",
+     *       "type": "long"
      *     },
      *     {
      *       "name": "NavigationSystem",
@@ -45,22 +32,6 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
-     *       "name": "Power",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "Prn",
-     *       "type": "int"
-     *     },
-     *     {
-     *       "name": "Psr",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "Satellite",
-     *       "type": "string"
-     *     },
-     *     {
      *       "name": "SignalType",
      *       "type": {
      *         "name": "NovAtelLogReader.LogData.SignalType",
@@ -78,13 +49,42 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
-     *       "name": "Timestamp",
-     *       "type": "long"
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
+     *       "name": "Prn",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "GloFreq",
+     *       "type": "int"
+     *     },
+     *     {
+     *       "name": "Psr",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Adr",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "CNo",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "LockTime",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Power",
+     *       "type": "double"
      *     }
      *   ]
      * }
      *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "RANGE", Queue = "datapoint-raw-range")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatvis.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatvis.cs
@@ -11,19 +11,7 @@ namespace NovAtelLogReader.DataPoints
      *   "type": "record",
      *   "fields": [
      *     {
-     *       "name": "Az",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "Elev",
-     *       "type": "double"
-     *     },
-     *     {
-     *       "name": "GloFreq",
-     *       "type": "int"
-     *     },
-     *     {
-     *       "name": "Health",
+     *       "name": "Timestamp",
      *       "type": "long"
      *     },
      *     {
@@ -44,25 +32,38 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
+     *       "name": "Satellite",
+     *       "type": "string"
+     *     },
+     *     {
      *       "name": "Prn",
      *       "type": "int"
      *     },
      *     {
-     *       "name": "Satellite",
-     *       "type": "string"
+     *       "name": "GloFreq",
+     *       "type": "int"
      *     },
      *     {
      *       "name": "SatVis",
      *       "type": "boolean"
      *     },
      *     {
-     *       "name": "Timestamp",
+     *       "name": "Health",
      *       "type": "long"
+     *     },
+     *     {
+     *       "name": "Elev",
+     *       "type": "double"
+     *     },
+     *     {
+     *       "name": "Az",
+     *       "type": "double"
      *     }
      *   ]
      * }
      *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "SATVIS", Queue = "datapoint-raw-satvis")]

--- a/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatxyz2.cs
+++ b/NovAtelLogReader/NovAtelLogReader/DataPoints/DataPointSatxyz2.cs
@@ -6,11 +6,14 @@ namespace NovAtelLogReader.DataPoints
 {
     /*
      *
-     *
      * {
      *   "name": "NovAtelLogReader.DataPoints.DataPointSatxyz2",
      *   "type": "record",
      *   "fields": [
+     *     {
+     *       "name": "Timestamp",
+     *       "type": "long"
+     *     },
      *     {
      *       "name": "NavigationSystem",
      *       "type": {
@@ -29,16 +32,12 @@ namespace NovAtelLogReader.DataPoints
      *       }
      *     },
      *     {
-     *       "name": "Prn",
-     *       "type": "int"
-     *     },
-     *     {
      *       "name": "Satellite",
      *       "type": "string"
      *     },
      *     {
-     *       "name": "Timestamp",
-     *       "type": "long"
+     *       "name": "Prn",
+     *       "type": "int"
      *     },
      *     {
      *       "name": "X",
@@ -54,7 +53,9 @@ namespace NovAtelLogReader.DataPoints
      *     }
      *   ]
      * }
+     *
      * */
+
     [DataContract]
     [Serializable]
     [DataPoint(Name = "SATXYZ2", Queue = "datapoint-raw-satxyz2")]


### PR DESCRIPTION
Исправляет порядок полей в Avro-схемах сообщений.

По какой-то причине поля с схемах данных оказались переупорядочены, что критично при бинарной десериализации на приёмной стороне.

Issued-by: 09c35ab Import AVSC files for Avro-serializable objects